### PR TITLE
feat: Implement LLM factory for OpenAI and Anthropic direct API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Email Audit Pipeline
 
-This project implements an automated pipeline for auditing email content. The pipeline processes .eml files, converts them to HTML, and performs various audits based on configurable rules.
+This project implements an automated pipeline for auditing email content. The pipeline processes .eml files, converts them to HTML, uses AI language models to analyze content, and performs various audits based on configurable rules.
 
 ## Features
 
 - EML to HTML conversion
-- Configurable audit rules
+- AI-powered content analysis and structuring using OpenAI and/or Anthropic models.
+- Configurable audit rules and LLM models.
 - Detailed audit reports
 - Error handling and logging
 - Modular and extensible architecture
@@ -14,13 +15,15 @@ This project implements an automated pipeline for auditing email content. The pi
 
 ```
 .
+├── .env.local          # Local environment variables (contains API keys, etc.)
 ├── eml-input/          # Input directory for .eml files
 ├── eml-html/           # Output directory for converted HTML files
 ├── reports/            # Output directory for audit reports
 ├── src/
 │   └── email_audit/
 │       ├── parser/     # EML to HTML conversion
-│       ├── auditor/    # Email content auditing
+│       ├── auditor/    # Email content auditing (integrates LLMs)
+│       ├── llm/        # LLM client implementations and factory
 │       ├── reporter/   # Report generation
 │       └── utils/      # Utility functions
 └── requirements.txt    # Python dependencies
@@ -28,75 +31,113 @@ This project implements an automated pipeline for auditing email content. The pi
 
 ## Setup
 
-1. Create a virtual environment:
-   ```bash
-   python -m venv .venv
-   source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-   ```
+1.  **Clone the repository.**
+2.  **Create and activate a virtual environment:**
+    ```bash
+    python -m venv .venv
+    source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+    ```
+3.  **Install dependencies:**
+    The system uses Python libraries such as `openai` and `anthropic` for interacting with language models.
+    ```bash
+    pip install -r requirements.txt
+    ```
+4.  **Configure Environment Variables:**
+    Create a `.env.local` file in the project root directory by copying the `.env.example` file (if one exists) or by creating it manually. This file will store your API keys and LLM preferences.
 
-2. Install dependencies:
-   ```bash
-   pip install -r requirements.txt
-   ```
+    *See the "Configuration" section below for details on the required and optional environment variables.*
+
+## Configuration
+
+The pipeline is configured using environment variables. Ensure these are set in your `.env.local` file or your system environment.
+
+### Core API Keys (Required)
+
+*   `OPENAI_API_KEY`: Your API key for OpenAI services.
+*   `ANTHROPIC_API_KEY`: Your API key for Anthropic services.
+
+*You need to provide at least one of the above, depending on which provider(s) you intend to use.*
+
+### LLM Provider and Model Selection (Optional)
+
+These variables allow you to specify which LLM provider and model to use for different stages of the audit. The system defaults to using OpenAI for all roles if these are not set.
+
+*   **Primary LLM (for structuring email content):**
+    *   `PRIMARY_LLM_PROVIDER`: Provider to use. Can be `"openai"` or `"anthropic"`. (Default: `"openai"`)
+    *   `OPENAI_PRIMARY_MODEL`: OpenAI model name. (Default: `"gpt-4"`)
+    *   `ANTHROPIC_PRIMARY_MODEL`: Anthropic model name. (Default: `"claude-3-opus-20240229"`)
+
+*   **Reasoning LLM (for comprehensive audit report generation):**
+    *   `REASONING_LLM_PROVIDER`: Provider to use. Can be `"openai"` or `"anthropic"`. (Default: `"openai"`)
+    *   `OPENAI_REASONING_MODEL`: OpenAI model name. (Default: `"gpt-4"`)
+    *   `ANTHROPIC_REASONING_MODEL`: Anthropic model name. (Default: `"claude-3-opus-20240229"`)
+
+*   **Detail LLM (initialized but not heavily used in the current main audit flow):**
+    *   `DETAIL_LLM_PROVIDER`: Provider to use. Can be `"openai"` or `"anthropic"`. (Default: `"openai"`)
+    *   `OPENAI_DETAIL_MODEL`: OpenAI model name. (Default: `"gpt-4"`)
+    *   `ANTHROPIC_DETAIL_MODEL`: Anthropic model name. (Default: `"claude-3-opus-20240229"`)
+
+**Example `.env.local` content:**
+```env
+OPENAI_API_KEY="your_openai_key_here"
+ANTHROPIC_API_KEY="your_anthropic_key_here"
+
+PRIMARY_LLM_PROVIDER="openai"
+OPENAI_PRIMARY_MODEL="gpt-4-turbo-preview"
+
+REASONING_LLM_PROVIDER="anthropic"
+ANTHROPIC_REASONING_MODEL="claude-3-haiku-20240307"
+# If REASONING_LLM_PROVIDER was "openai", you might set:
+# OPENAI_REASONING_MODEL="gpt-3.5-turbo"
+```
 
 ## Usage
 
-1. Place your .eml files in the `eml-input` directory.
-
-2. Run the pipeline:
-   ```bash
-   python -m src.email_audit.pipeline
-   ```
-
-3. Check the results:
-   - Converted HTML files will be in the `eml-html` directory
-   - Audit reports will be in the `reports` directory
-   - Logs will be in `pipeline.log`
+1.  Place your .eml files in the `eml-input` directory.
+2.  Ensure your `.env.local` file is correctly configured with API keys and any desired LLM settings.
+3.  Run the pipeline:
+    ```bash
+    python -m src.email_audit.pipeline
+    ```
+4.  Check the results:
+    *   Converted HTML files will be in the `eml-html` directory.
+    *   Audit reports (JSON format) will be in the `reports` directory.
+    *   Logs will be in `pipeline.log`.
 
 ## Audit Rules
 
-The current implementation includes the following audit rules:
+The audit process involves multiple steps defined within the `EmailAuditor` class. These steps leverage LLMs to analyze aspects of the email conversation, such as:
+- Logical itinerary planning
+- Application of frequent flyer and loyalty programs
+- Adherence to client policies and service standards
+- Communication quality
 
-1. HTML Structure Check
-   - Verifies proper HTML structure
-   - Checks for essential HTML tags
-   - Validates content structure
-
-2. Content Length Check
-   - Ensures sufficient content length
-   - Provides scoring based on content size
-
-## Adding New Rules
-
-To add new audit rules:
-
-1. Open `src/email_audit/auditor/email_auditor.py`
-2. Add a new rule to the `_initialize_rules` method
-3. Implement the corresponding check method
-4. The rule will be automatically included in the audit process
+(The "Audit Rules" and "Adding New Rules" sections from the old README were high-level and might need more specific updates if the internal rule definition mechanism significantly changes beyond just LLM invocation.)
 
 ## Report Format
 
 Audit reports are generated in JSON format and include:
 
 - Overall score
-- Number of passed/failed rules
-- Detailed results for each rule
+- Detailed results for each audit step, including scores, analysis, and reasoning provided by the LLM.
 - Human-readable summary
 - Timestamp of the audit
+- Conversation history
 
 ## Error Handling
 
 The pipeline includes comprehensive error handling:
 
-- Individual file processing errors are logged
-- Failed rules are reported but don't stop the pipeline
-- All errors are logged with detailed information
+- Individual file processing errors are logged.
+- LLM invocation errors or parsing issues are logged.
+- Failed audit steps are reported but don't stop the pipeline.
+- All errors are logged with detailed information.
 
 ## Contributing
 
-1. Fork the repository
-2. Create a feature branch
-3. Commit your changes
-4. Push to the branch
-5. Create a Pull Request 
+1.  Fork the repository.
+2.  Create a feature branch.
+3.  Commit your changes.
+4.  Push to the branch.
+5.  Create a Pull Request.
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 beautifulsoup4==4.12.2
-langchain-openai
 loguru==0.7.2
-openai
 pydantic<2.11.0,>=2.10.4
 python-dotenv>=1.0.1
 python-eml==0.0.1
 requests>=2.32.3
 soupsieve
 typing-extensions
+openai>=1.0.0
+anthropic>=0.20.0

--- a/src/email_audit/llm/anthropic_llm.py
+++ b/src/email_audit/llm/anthropic_llm.py
@@ -1,0 +1,94 @@
+import json
+import os
+from typing import Optional, Type, Any, Dict
+from pydantic import BaseModel, ValidationError
+from anthropic import AsyncAnthropic # Use AsyncAnthropic for asynchronous operations
+
+from .base_llm import BaseLLM
+from loguru import logger
+
+class AnthropicLLM(BaseLLM):
+    def __init__(self, api_key: Optional[str] = None, model_name: str = "claude-3-opus-20240229", temperature: float = 0.0):
+        super().__init__(api_key, model_name, temperature)
+        self.api_key = api_key or self._get_env_var("ANTHROPIC_API_KEY")
+        if not self.api_key:
+            raise ValueError("Anthropic API key not found. Please set ANTHROPIC_API_KEY environment variable or pass it as an argument.")
+        self.client = AsyncAnthropic(api_key=self.api_key)
+
+    async def ainvoke(self, prompt: str, schema: Optional[Type[BaseModel]] = None) -> Optional[BaseModel | str]:
+        logger.debug(f"AnthropicLLM invoking model {self.model_name} with temperature {self.temperature}")
+        try:
+            system_prompt = ""
+            if schema:
+                # Instruct the model to return JSON matching the schema
+                # This is a common approach for Anthropic models when specific tool use/function calling is not as mature or desired.
+                schema_json = schema.model_json_schema()
+                # Remove "title" from schema_json if present, as it can sometimes confuse the model
+                if "title" in schema_json:
+                    del schema_json["title"]
+
+                system_prompt = (
+                    "You are a helpful assistant that always responds in JSON format. "
+                    "Please provide a response that strictly adheres to the following JSON schema. "
+                    "Do not include any explanatory text or markdown formatting before or after the JSON object. "
+                    "The entire response must be a single valid JSON object.\n"
+                    f"JSON Schema:\n{json.dumps(schema_json)}"
+                )
+                logger.debug(f"Anthropic system prompt for schema {schema.__name__}:\n{system_prompt}")
+
+
+            messages = [{"role": "user", "content": prompt}]
+
+            response = await self.client.messages.create(
+                model=self.model_name,
+                max_tokens=4096, # Recommended max_tokens for Claude 3 Opus, adjust as needed
+                temperature=self.temperature,
+                system=system_prompt if system_prompt else None, # System prompt for structured JSON output
+                messages=messages
+            )
+
+            logger.debug(f"Anthropic response: {response}")
+
+            if response.content and isinstance(response.content, list) and len(response.content) > 0:
+                # Assuming the first content block is the one we want, and it's of type TextBlock
+                raw_response_content = response.content[0].text if hasattr(response.content[0], 'text') else None
+
+                if not raw_response_content:
+                    logger.warning("No text content found in Anthropic response block.")
+                    return None
+
+                logger.debug(f"Raw Anthropic response content: {raw_response_content}")
+
+                if schema:
+                    try:
+                        # Attempt to parse the JSON string into the Pydantic model
+                        # Remove potential markdown code block fences if the model adds them
+                        cleaned_json_string = raw_response_content.strip()
+                        if cleaned_json_string.startswith("```json"):
+                            cleaned_json_string = cleaned_json_string[7:]
+                        if cleaned_json_string.endswith("```"):
+                            cleaned_json_string = cleaned_json_string[:-3]
+
+                        cleaned_json_string = cleaned_json_string.strip()
+
+                        data = json.loads(cleaned_json_string)
+                        return schema(**data)
+                    except json.JSONDecodeError as e:
+                        logger.error(f"JSONDecodeError parsing Anthropic response: {e}, content: {raw_response_content}")
+                        # Fallback: return the raw string if JSON parsing fails, so it can be inspected
+                        return raw_response_content
+                    except ValidationError as e:
+                        logger.error(f"Pydantic ValidationError for Anthropic response: {e}, content: {raw_response_content}")
+                        # Fallback: return the raw string
+                        return raw_response_content
+                else:
+                    # No schema, return the raw text content
+                    return raw_response_content
+            else:
+                logger.warning("No content blocks found in Anthropic response.")
+                return None
+
+        except Exception as e:
+            logger.error(f"Error invoking Anthropic model {self.model_name}: {e}")
+            # Consider re-raising or returning a specific error object
+            return None

--- a/src/email_audit/llm/base_llm.py
+++ b/src/email_audit/llm/base_llm.py
@@ -1,0 +1,42 @@
+import abc
+import os
+from typing import Optional, Type
+from pydantic import BaseModel
+
+class BaseLLM(abc.ABC):
+    def __init__(self, api_key: Optional[str], model_name: str, temperature: float):
+        """
+        Initializes the base LLM.
+
+        Args:
+            api_key: The API key for the LLM provider. If None, it will be fetched from the environment variable.
+            model_name: The name of the model to use.
+            temperature: The temperature to use for generation.
+        """
+        self.api_key = api_key
+        self.model_name = model_name
+        self.temperature = temperature
+
+    @abc.abstractmethod
+    async def ainvoke(self, prompt: str, schema: Optional[Type[BaseModel]] = None) -> Optional[BaseModel | str]:
+        """
+        Invokes the language model with the given prompt.
+
+        Args:
+            prompt: The prompt to send to the model.
+            schema: An optional Pydantic schema. If provided, the LLM is expected
+                    to return a response that can be parsed into this schema.
+                    If not provided, the LLM should return a string.
+
+        Returns:
+            A Pydantic model instance if a schema is provided and parsing is successful,
+            or a string if no schema is provided or parsing fails (though ideally,
+            implementations should try to enforce schema compliance or handle errors).
+            Returns None if the invocation fails.
+        """
+        pass
+
+    @staticmethod
+    def _get_env_var(name: str) -> Optional[str]:
+        """Helper to get environment variables."""
+        return os.getenv(name)

--- a/src/email_audit/llm/llm_factory.py
+++ b/src/email_audit/llm/llm_factory.py
@@ -1,0 +1,87 @@
+from typing import Optional
+from .base_llm import BaseLLM
+from .openai_llm import OpenAILLM
+from .anthropic_llm import AnthropicLLM
+from loguru import logger
+
+class LLMFactory:
+    @staticmethod
+    def create_llm(
+        provider: str,
+        model_name: str,
+        temperature: float,
+        api_key: Optional[str] = None
+    ) -> BaseLLM:
+        """
+        Creates an instance of a language model client.
+
+        Args:
+            provider: The LLM provider to use (e.g., "openai", "anthropic").
+            model_name: The specific model name to use.
+            temperature: The sampling temperature for the model.
+            api_key: Optional API key. If not provided, the respective
+                     LLM class will attempt to load it from environment variables.
+
+        Returns:
+            An instance of BaseLLM (either OpenAILLM or AnthropicLLM).
+
+        Raises:
+            ValueError: If an unsupported provider is specified.
+        """
+        logger.info(f"Creating LLM for provider: {provider}, model: {model_name}, temperature: {temperature}")
+        provider_lower = provider.lower()
+
+        if provider_lower == "openai":
+            return OpenAILLM(api_key=api_key, model_name=model_name, temperature=temperature)
+        elif provider_lower == "anthropic":
+            return AnthropicLLM(api_key=api_key, model_name=model_name, temperature=temperature)
+        else:
+            logger.error(f"Unsupported LLM provider: {provider}")
+            raise ValueError(f"Unsupported LLM provider: {provider}. Supported providers are 'openai' and 'anthropic'.")
+
+# Example usage (optional, for testing or demonstration):
+# if __name__ == "__main__":
+#     # Make sure to set OPENAI_API_KEY and ANTHROPIC_API_KEY environment variables
+#     # or pass them directly if you uncomment the api_key arguments.
+#
+#     try:
+#         openai_llm = LLMFactory.create_llm(
+#             provider="openai",
+#             model_name="gpt-3.5-turbo", # Or your preferred model
+#             temperature=0.1,
+#             # api_key="your_openai_api_key_here" # Optional
+#         )
+#         logger.info(f"Successfully created OpenAILLM: {type(openai_llm)}")
+#
+#         # Example invocation (requires async context)
+#         # import asyncio
+#         # async def test_openai():
+#         #     response = await openai_llm.ainvoke("Hello, OpenAI!")
+#         #     logger.info(f"OpenAI Response: {response}")
+#         # asyncio.run(test_openai())
+#
+#     except ValueError as e:
+#         logger.error(f"Error creating OpenAI LLM: {e}")
+#     except Exception as e:
+#         logger.error(f"An unexpected error occurred with OpenAI: {e}")
+#
+#     try:
+#         anthropic_llm = LLMFactory.create_llm(
+#             provider="anthropic",
+#             model_name="claude-3-haiku-20240307", # Or your preferred model
+#             temperature=0.1,
+#             # api_key="your_anthropic_api_key_here" # Optional
+#         )
+#         logger.info(f"Successfully created AnthropicLLM: {type(anthropic_llm)}")
+#
+#         # Example invocation (requires async context)
+#         # import asyncio
+#         # async def test_anthropic():
+#         #     response = await anthropic_llm.ainvoke("Hello, Anthropic!")
+#         #     logger.info(f"Anthropic Response: {response}")
+#         # asyncio.run(test_anthropic())
+#
+#     except ValueError as e:
+#         logger.error(f"Error creating Anthropic LLM: {e}")
+#     except Exception as e:
+#         logger.error(f"An unexpected error occurred with Anthropic: {e}")

--- a/src/email_audit/llm/openai_llm.py
+++ b/src/email_audit/llm/openai_llm.py
@@ -1,0 +1,110 @@
+import json
+import os
+import re # Added import re
+from typing import Optional, Type, Any, Dict
+from pydantic import BaseModel, ValidationError
+from openai import AsyncOpenAI # Use AsyncOpenAI for asynchronous operations
+
+from .base_llm import BaseLLM
+from loguru import logger
+
+class OpenAILLM(BaseLLM):
+    def __init__(self, api_key: Optional[str] = None, model_name: str = "gpt-4", temperature: float = 0.0):
+        super().__init__(api_key, model_name, temperature)
+        self.api_key = api_key or self._get_env_var("OPENAI_API_KEY")
+        if not self.api_key:
+            raise ValueError("OpenAI API key not found. Please set OPENAI_API_KEY environment variable or pass it as an argument.")
+        self.client = AsyncOpenAI(api_key=self.api_key)
+
+    async def ainvoke(self, prompt: str, schema: Optional[Type[BaseModel]] = None) -> Optional[BaseModel | str]:
+        logger.debug(f"OpenAILLM invoking model {self.model_name} with temperature {self.temperature}")
+        try:
+            messages = [{"role": "user", "content": prompt}]
+            if schema:
+                tools = [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "structured_output",
+                            "description": f"Parses the output according to the provided schema: {schema.__name__}",
+                            "parameters": schema.model_json_schema()
+                        }
+                    }
+                ]
+                tool_choice = {"type": "function", "function": {"name": "structured_output"}}
+
+                logger.debug(f"Using tool choice: {tool_choice}")
+                logger.debug(f"Schema for tool: {schema.model_json_schema()}")
+
+                response = await self.client.chat.completions.create(
+                    model=self.model_name,
+                    messages=messages,
+                    temperature=self.temperature,
+                    tools=tools,
+                    tool_choice=tool_choice,
+                )
+
+                logger.debug(f"OpenAI response: {response}")
+
+                if response.choices and response.choices[0].message.tool_calls:
+                    tool_call = response.choices[0].message.tool_calls[0]
+                    if tool_call.function.name == "structured_output":
+                        try:
+                            arguments = json.loads(tool_call.function.arguments)
+                            return schema(**arguments)
+                        except json.JSONDecodeError as e:
+                            logger.error(f"JSONDecodeError parsing arguments: {tool_call.function.arguments}, error: {e}")
+                            logger.error(f"Attempting to parse a more resilient way, raw arguments: {tool_call.function.arguments}")
+                            # Attempt to fix common JSON issues, like trailing commas or escaped quotes.
+                            # This is a basic attempt; more sophisticated error handling might be needed.
+                            try:
+                                # Replace escaped single quotes if they are causing issues with simplejson
+                                fixed_args = tool_call.function.arguments.replace("\\'", "'")
+                                # Remove trailing commas before closing curly or square brackets
+                                fixed_args = re.sub(r',\s*([}\]])', r'\1', fixed_args)
+                                arguments = json.loads(fixed_args)
+                                return schema(**arguments)
+                            except Exception as inner_e:
+                                logger.error(f"Could not parse arguments even after attempting to fix them: {inner_e}")
+                                logger.error(f"Problematic raw arguments: {tool_call.function.arguments}")
+                                return None # Or raise an error, or return the raw string
+                        except ValidationError as e:
+                            logger.error(f"Pydantic ValidationError: {e}, arguments: {tool_call.function.arguments}")
+                            return None # Or raise an error
+                    else:
+                        logger.warning(f"Expected tool call 'structured_output', got '{tool_call.function.name}'")
+                        return None
+                else:
+                    logger.warning("No tool calls found in response when schema was provided.")
+                    # Fallback or error handling: what if the model doesn't use the tool?
+                    # Try to parse the content directly if available, or return None/error.
+                    if response.choices and response.choices[0].message.content:
+                        logger.warning("Falling back to parsing content directly as JSON.")
+                        try:
+                            # This assumes the model might return JSON even without the tool call.
+                            # This is less reliable.
+                            raw_content = response.choices[0].message.content
+                            parsed_content = json.loads(raw_content)
+                            return schema(**parsed_content)
+                        except Exception as e:
+                            logger.error(f"Could not parse content as JSON: {e}, content: {raw_content}")
+                            return raw_content # Return raw content as string if parsing fails
+                    return None
+            else:
+                # No schema, expect string output
+                response = await self.client.chat.completions.create(
+                    model=self.model_name,
+                    messages=messages,
+                    temperature=self.temperature,
+                )
+                logger.debug(f"OpenAI response (no schema): {response}")
+                if response.choices and response.choices[0].message.content:
+                    return response.choices[0].message.content
+                else:
+                    logger.warning("No content found in response when no schema was provided.")
+                    return None
+
+        except Exception as e:
+            logger.error(f"Error invoking OpenAI model {self.model_name}: {e}")
+            # Consider re-raising, or returning a specific error object
+            return None

--- a/src/email_audit/tests/auditor/__init__.py
+++ b/src/email_audit/tests/auditor/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the directory src/email_audit/tests/auditor as a package.

--- a/src/email_audit/tests/auditor/test_email_auditor.py
+++ b/src/email_audit/tests/auditor/test_email_auditor.py
@@ -1,0 +1,114 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+
+# Assuming EmailAuditor is in src.email_audit.auditor.email_auditor
+from src.email_audit.auditor.email_auditor import EmailAuditor
+from src.email_audit.llm.openai_llm import OpenAILLM
+from src.email_audit.llm.anthropic_llm import AnthropicLLM
+
+class TestEmailAuditorInit(unittest.TestCase):
+
+    @patch.dict(os.environ, {
+        "PRIMARY_LLM_PROVIDER": "openai",
+        "OPENAI_PRIMARY_MODEL": "gpt-primary",
+        "OPENAI_API_KEY": "fake_openai", # Needed by OpenAILLM constructor
+        "REASONING_LLM_PROVIDER": "anthropic",
+        "ANTHROPIC_REASONING_MODEL": "claude-reasoning",
+        "ANTHROPIC_API_KEY": "fake_anthropic", # Needed by AnthropicLLM constructor
+        "DETAIL_LLM_PROVIDER": "openai",
+        "OPENAI_DETAIL_MODEL": "gpt-detail",
+    }, clear=True)
+    @patch('src.email_audit.llm.llm_factory.LLMFactory.create_llm')
+    def test_init_llm_configuration(self, mock_create_llm):
+        # Mock the return values for create_llm
+        # It's important that these mock instances are distinguishable
+        mock_openai_primary = OpenAILLM(api_key="fake_openai", model_name="gpt-primary", temperature=0.0)
+        mock_anthropic_reasoning = AnthropicLLM(api_key="fake_anthropic", model_name="claude-reasoning", temperature=0.3)
+        mock_openai_detail = OpenAILLM(api_key="fake_openai", model_name="gpt-detail", temperature=0.1)
+
+        # Side effect to return different mocks based on provider and model
+        def side_effect_func(provider, model_name, temperature, api_key=None): # api_key is passed by factory
+            if provider == "openai" and model_name == "gpt-primary" and temperature == 0.0:
+                return mock_openai_primary
+            elif provider == "anthropic" and model_name == "claude-reasoning" and temperature == 0.3:
+                return mock_anthropic_reasoning
+            elif provider == "openai" and model_name == "gpt-detail" and temperature == 0.1:
+                return mock_openai_detail
+            # Fallback for unexpected calls, useful for debugging tests
+            m = MagicMock()
+            m.provider = provider
+            m.model_name = model_name
+            m.temperature = temperature
+            # raise ValueError(f"Unexpected call to mock_create_llm: provider='{provider}', model_name='{model_name}', temperature={temperature}")
+            return m # Return a generic mock if no conditions match, to make debugging easier.
+
+        mock_create_llm.side_effect = side_effect_func
+
+        auditor = EmailAuditor()
+
+        self.assertEqual(mock_create_llm.call_count, 3)
+
+        # Check calls to factory
+        # Using assert_any_call because the order of LLM initialization in EmailAuditor might not be guaranteed
+        # if it iterates over a dictionary or similar for different LLM roles.
+        # However, the current implementation initializes them sequentially.
+        mock_create_llm.assert_any_call(provider="openai", model_name="gpt-primary", temperature=0.0)
+        mock_create_llm.assert_any_call(provider="anthropic", model_name="claude-reasoning", temperature=0.3)
+        mock_create_llm.assert_any_call(provider="openai", model_name="gpt-detail", temperature=0.1)
+
+        self.assertIs(auditor.primary_llm, mock_openai_primary)
+        self.assertIs(auditor.reasoning_llm, mock_anthropic_reasoning)
+        self.assertIs(auditor.detail_llm, mock_openai_detail)
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_KEY": "fake_openai_key_default",
+        "ANTHROPIC_API_KEY": "fake_anthropic_key_default"
+        # Other _PROVIDER and _MODEL env vars are deliberately not set to test defaults
+    }, clear=True)
+    @patch('src.email_audit.llm.llm_factory.LLMFactory.create_llm')
+    def test_init_llm_default_providers_and_models(self, mock_create_llm):
+
+        # This side effect will be called by LLMFactory.create_llm
+        # It should simulate returning a real LLM instance based on input.
+        def side_effect_default(provider, model_name, temperature, api_key=None):
+            if provider == "openai":
+                # The factory passes api_key=None, so the LLM class will try to load from env.
+                # We've patched os.environ to include the fake keys.
+                return OpenAILLM(api_key=os.getenv("OPENAI_API_KEY"), model_name=model_name, temperature=temperature)
+            elif provider == "anthropic":
+                return AnthropicLLM(api_key=os.getenv("ANTHROPIC_API_KEY"), model_name=model_name, temperature=temperature)
+            raise ValueError(f"Unexpected provider for default test: {provider}")
+
+        mock_create_llm.side_effect = side_effect_default
+
+        auditor = EmailAuditor() # This will call the factory, which calls our side_effect
+
+        self.assertEqual(mock_create_llm.call_count, 3)
+        # Based on EmailAuditor's defaults if env vars are not set:
+        # primary_llm_provider defaults to 'openai', model to DEFAULT_OPENAI_PRIMARY_MODEL ("gpt-4")
+        # reasoning_llm_provider defaults to 'openai', model to DEFAULT_OPENAI_REASONING_MODEL ("gpt-4")
+        # detail_llm_provider defaults to 'openai', model to DEFAULT_OPENAI_DETAIL_MODEL ("gpt-4")
+        mock_create_llm.assert_any_call(provider="openai", model_name="gpt-4", temperature=0.0)
+        mock_create_llm.assert_any_call(provider="openai", model_name="gpt-4", temperature=0.3)
+        mock_create_llm.assert_any_call(provider="openai", model_name="gpt-4", temperature=0.1)
+
+        self.assertIsInstance(auditor.primary_llm, OpenAILLM)
+        self.assertEqual(auditor.primary_llm.model_name, "gpt-4")
+        self.assertEqual(auditor.primary_llm.temperature, 0.0)
+        self.assertTrue(auditor.primary_llm.api_key, "fake_openai_key_default")
+
+
+        self.assertIsInstance(auditor.reasoning_llm, OpenAILLM)
+        self.assertEqual(auditor.reasoning_llm.model_name, "gpt-4")
+        self.assertEqual(auditor.reasoning_llm.temperature, 0.3)
+        self.assertTrue(auditor.reasoning_llm.api_key, "fake_openai_key_default")
+
+        self.assertIsInstance(auditor.detail_llm, OpenAILLM)
+        self.assertEqual(auditor.detail_llm.model_name, "gpt-4")
+        self.assertEqual(auditor.detail_llm.temperature, 0.1)
+        self.assertTrue(auditor.detail_llm.api_key, "fake_openai_key_default")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/email_audit/tests/llm/__init__.py
+++ b/src/email_audit/tests/llm/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the directory src/email_audit/tests/llm as a package.

--- a/src/email_audit/tests/llm/test_anthropic_llm.py
+++ b/src/email_audit/tests/llm/test_anthropic_llm.py
@@ -1,0 +1,112 @@
+import unittest
+from unittest.mock import patch, AsyncMock
+from pydantic import BaseModel, Field
+from anthropic.types import Message, TextBlock
+
+from src.email_audit.llm.anthropic_llm import AnthropicLLM
+import os
+
+class SampleSchema(BaseModel):
+    item: str = Field(..., description="Name of the item")
+    quantity: int = Field(..., description="Quantity of the item")
+
+class TestAnthropicLLM(unittest.IsolatedAsyncioTestCase):
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "fake_anthropic_key"}, clear=True)
+    def setUp(self):
+        self.llm = AnthropicLLM(model_name="claude-test", temperature=0.2)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_init_no_api_key(self):
+        with self.assertRaises(ValueError) as context:
+            AnthropicLLM()
+        self.assertIn("Anthropic API key not found", str(context.exception))
+
+    @patch('anthropic.AsyncAnthropic')
+    async def test_ainvoke_string_output(self, MockAsyncAnthropic):
+        mock_client = MockAsyncAnthropic.return_value
+        mock_response_message = Message(
+            id="msg-xxxx",
+            type="message",
+            role="assistant",
+            content=[TextBlock(type="text", text="Hello from Anthropic!")],
+            model="claude-test",
+            stop_reason="end_turn",
+            stop_sequence=None,
+            usage={"input_tokens": 10, "output_tokens": 10}
+        )
+        mock_client.messages.create = AsyncMock(return_value=mock_response_message)
+
+        response = await self.llm.ainvoke("Anthropic test prompt")
+        self.assertEqual(response, "Hello from Anthropic!")
+        mock_client.messages.create.assert_called_once()
+        call_args = mock_client.messages.create.call_args[1]
+        self.assertEqual(call_args['messages'][0]['content'], "Anthropic test prompt")
+        self.assertIsNone(call_args['system']) # No schema, so no system prompt
+
+    @patch('anthropic.AsyncAnthropic')
+    async def test_ainvoke_structured_output_success(self, MockAsyncAnthropic):
+        mock_client = MockAsyncAnthropic.return_value
+        response_text = '{"item": "Widget", "quantity": 100}'
+        mock_response_message = Message(
+            id="msg-yyyy",
+            type="message",
+            role="assistant",
+            content=[TextBlock(type="text", text=response_text)],
+            model="claude-test",
+            stop_reason="end_turn",
+            stop_sequence=None,
+            usage={"input_tokens": 10, "output_tokens": 20}
+        )
+        mock_client.messages.create = AsyncMock(return_value=mock_response_message)
+
+        response = await self.llm.ainvoke("Anthropic schema prompt", schema=SampleSchema)
+        self.assertIsInstance(response, SampleSchema)
+        self.assertEqual(response.item, "Widget")
+        self.assertEqual(response.quantity, 100)
+        mock_client.messages.create.assert_called_once()
+        call_args = mock_client.messages.create.call_args[1]
+        self.assertIn("JSON format", call_args['system']) # System prompt should request JSON
+
+    @patch('anthropic.AsyncAnthropic')
+    async def test_ainvoke_structured_output_json_malformed(self, MockAsyncAnthropic):
+        mock_client = MockAsyncAnthropic.return_value
+        response_text = '{"item": "Gadget", "quantity": "not_an_integer"}' # Malformed
+        mock_response_message = Message(
+            id="msg-zzzz",
+            type="message",
+            role="assistant",
+            content=[TextBlock(type="text", text=response_text)],
+            model="claude-test",
+            stop_reason="end_turn",
+            stop_sequence=None,
+            usage={"input_tokens": 10, "output_tokens": 20}
+        )
+        mock_client.messages.create = AsyncMock(return_value=mock_response_message)
+        # Expecting raw string due to Pydantic error being logged and raw returned by LLM class
+        response = await self.llm.ainvoke("Anthropic schema error prompt", schema=SampleSchema)
+        self.assertEqual(response, response_text)
+
+    @patch('anthropic.AsyncAnthropic')
+    async def test_ainvoke_structured_output_with_markdown_fences(self, MockAsyncAnthropic):
+        mock_client = MockAsyncAnthropic.return_value
+        response_text = '```json\n{"item": "Gizmo", "quantity": 75}\n```'
+        mock_response_message = Message(
+            id="msg-aaaa",
+            type="message",
+            role="assistant",
+            content=[TextBlock(type="text", text=response_text)],
+            model="claude-test",
+            stop_reason="end_turn",
+            stop_sequence=None,
+            usage={"input_tokens": 10, "output_tokens": 25}
+        )
+        mock_client.messages.create = AsyncMock(return_value=mock_response_message)
+
+        response = await self.llm.ainvoke("Anthropic schema with fences", schema=SampleSchema)
+        self.assertIsInstance(response, SampleSchema)
+        self.assertEqual(response.item, "Gizmo")
+        self.assertEqual(response.quantity, 75)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/email_audit/tests/llm/test_base_llm.py
+++ b/src/email_audit/tests/llm/test_base_llm.py
@@ -1,0 +1,30 @@
+import unittest
+from src.email_audit.llm.base_llm import BaseLLM
+from pydantic import BaseModel
+
+class MockLLM(BaseLLM):
+    async def ainvoke(self, prompt: str, schema: type[BaseModel] | None = None) -> BaseModel | str | None:
+        if schema:
+            # Create a dummy instance of the schema if it has no required fields
+            # or handle specific test schemas appropriately.
+            # For a generic case, if schema has no args, schema() works.
+            # If it has required fields, this would fail without defaults.
+            # For this test, we assume it's a simple schema or this part isn't the focus.
+            try:
+                return schema()
+            except Exception: # If schema() fails due to missing required fields
+                # Fallback for complex schemas in a generic mock, consider a more specific mock if needed
+                class DummyModel(BaseModel):
+                    message: str = "dummy model for complex schema"
+                return DummyModel()
+        return "test response"
+
+class TestBaseLLM(unittest.TestCase):
+    def test_base_llm_creation(self):
+        llm = MockLLM(api_key="test_key", model_name="test_model", temperature=0.5)
+        self.assertEqual(llm.api_key, "test_key")
+        self.assertEqual(llm.model_name, "test_model")
+        self.assertEqual(llm.temperature, 0.5)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/email_audit/tests/llm/test_llm_factory.py
+++ b/src/email_audit/tests/llm/test_llm_factory.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import patch
+import os
+
+from src.email_audit.llm.llm_factory import LLMFactory
+from src.email_audit.llm.openai_llm import OpenAILLM
+from src.email_audit.llm.anthropic_llm import AnthropicLLM
+
+class TestLLMFactory(unittest.TestCase):
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "fake_key", "ANTHROPIC_API_KEY": "fake_key"}, clear=True)
+    def test_create_openai_llm(self):
+        llm = LLMFactory.create_llm(provider="openai", model_name="gpt-test-factory", temperature=0.3)
+        self.assertIsInstance(llm, OpenAILLM)
+        self.assertEqual(llm.model_name, "gpt-test-factory")
+        self.assertEqual(llm.temperature, 0.3)
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "fake_key", "ANTHROPIC_API_KEY": "fake_key"}, clear=True)
+    def test_create_anthropic_llm(self):
+        llm = LLMFactory.create_llm(provider="anthropic", model_name="claude-test-factory", temperature=0.4)
+        self.assertIsInstance(llm, AnthropicLLM)
+        self.assertEqual(llm.model_name, "claude-test-factory")
+        self.assertEqual(llm.temperature, 0.4)
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "fake_key", "ANTHROPIC_API_KEY": "fake_key"}, clear=True)
+    def test_create_llm_case_insensitive_provider(self):
+        llm_openai = LLMFactory.create_llm(provider="OpenAI", model_name="gpt-test-case", temperature=0.1)
+        self.assertIsInstance(llm_openai, OpenAILLM)
+        llm_anthropic = LLMFactory.create_llm(provider="Anthropic", model_name="claude-test-case", temperature=0.2)
+        self.assertIsInstance(llm_anthropic, AnthropicLLM)
+
+    def test_create_unsupported_provider(self):
+        with self.assertRaises(ValueError) as context:
+            LLMFactory.create_llm(provider="unsupported", model_name="test", temperature=0.5)
+        self.assertIn("Unsupported LLM provider: unsupported", str(context.exception))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/email_audit/tests/llm/test_openai_llm.py
+++ b/src/email_audit/tests/llm/test_openai_llm.py
@@ -1,0 +1,128 @@
+import unittest
+from unittest.mock import patch, AsyncMock
+from pydantic import BaseModel, Field
+from openai.types.chat import ChatCompletionMessage, ChatCompletion
+from openai.types.chat.chat_completion import Choice # Added
+from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall, Function
+
+from src.email_audit.llm.openai_llm import OpenAILLM
+import os
+
+class SampleSchema(BaseModel):
+    name: str = Field(..., description="Name of the person")
+    age: int = Field(..., description="Age of the person")
+
+class TestOpenAILLM(unittest.IsolatedAsyncioTestCase):
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "fake_key"}, clear=True)
+    def setUp(self):
+        self.llm = OpenAILLM(model_name="gpt-test", temperature=0.1)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_init_no_api_key(self):
+        with self.assertRaises(ValueError) as context:
+            OpenAILLM()
+        self.assertIn("OpenAI API key not found", str(context.exception))
+
+    @patch('openai.AsyncOpenAI')
+    async def test_ainvoke_string_output(self, MockAsyncOpenAI):
+        mock_client = MockAsyncOpenAI.return_value
+        mock_completion = ChatCompletion(
+            id="chatcmpl-xxxx",
+            choices=[
+                Choice(finish_reason="stop", index=0, message=ChatCompletionMessage(role="assistant", content="Hello, world!"))
+            ],
+            created=12345,
+            model="gpt-test",
+            object="chat.completion",
+            system_fingerprint=None,
+            usage=None
+        )
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+
+        response = await self.llm.ainvoke("Test prompt")
+        self.assertEqual(response, "Hello, world!")
+        mock_client.chat.completions.create.assert_called_once_with(
+            model="gpt-test",
+            messages=[{"role": "user", "content": "Test prompt"}],
+            temperature=0.1
+        )
+
+    @patch('openai.AsyncOpenAI')
+    async def test_ainvoke_structured_output_success(self, MockAsyncOpenAI):
+        mock_client = MockAsyncOpenAI.return_value
+        tool_call = ChatCompletionMessageToolCall(
+            id="toolcall-xxxx",
+            function=Function(name="structured_output", arguments='{"name": "John Doe", "age": 30}'),
+            type="function"
+        )
+        mock_completion = ChatCompletion(
+            id="chatcmpl-yyyy",
+            choices=[
+                Choice(finish_reason="tool_calls", index=0, message=ChatCompletionMessage(role="assistant", content=None, tool_calls=[tool_call]))
+            ],
+            created=12345,
+            model="gpt-test",
+            object="chat.completion",
+            system_fingerprint=None,
+            usage=None
+        )
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+
+        response = await self.llm.ainvoke("Test prompt for schema", schema=SampleSchema)
+        self.assertIsInstance(response, SampleSchema)
+        self.assertEqual(response.name, "John Doe")
+        self.assertEqual(response.age, 30)
+        mock_client.chat.completions.create.assert_called_once()
+        call_args = mock_client.chat.completions.create.call_args[1]
+        self.assertEqual(call_args['tools'][0]['function']['name'], "structured_output")
+
+    @patch('openai.AsyncOpenAI')
+    async def test_ainvoke_structured_output_json_malformed(self, MockAsyncOpenAI):
+        mock_client = MockAsyncOpenAI.return_value
+        tool_call = ChatCompletionMessageToolCall(
+            id="toolcall-zzzz",
+            function=Function(name="structured_output", arguments='{"name": "Jane Doe", "age": "not_an_int"}'), # Malformed age
+            type="function"
+        )
+        mock_completion = ChatCompletion(
+            id="chatcmpl-aaaa",
+            choices=[
+                Choice(finish_reason="tool_calls", index=0, message=ChatCompletionMessage(role="assistant", content=None, tool_calls=[tool_call]))
+            ],
+            created=12345,
+            model="gpt-test",
+            object="chat.completion",
+            system_fingerprint=None,
+            usage=None
+        )
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+        # Expecting None due to Pydantic ValidationError logged by the LLM class
+        response = await self.llm.ainvoke("Test prompt for schema error", schema=SampleSchema)
+        self.assertIsNone(response)
+
+
+    @patch('openai.AsyncOpenAI')
+    async def test_ainvoke_no_tool_call_fallback(self, MockAsyncOpenAI):
+        mock_client = MockAsyncOpenAI.return_value
+        # Simulate model not making a tool call but returning JSON in content
+        mock_completion = ChatCompletion(
+            id="chatcmpl-bbbb",
+            choices=[
+                Choice(finish_reason="stop", index=0, message=ChatCompletionMessage(role="assistant", content='{"name": "Fallback Fred", "age": 45}'))
+            ],
+            created=12345,
+            model="gpt-test",
+            object="chat.completion",
+            system_fingerprint=None,
+            usage=None
+        )
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+        response = await self.llm.ainvoke("Test prompt for schema fallback", schema=SampleSchema)
+        self.assertIsInstance(response, SampleSchema)
+        self.assertEqual(response.name, "Fallback Fred")
+        self.assertEqual(response.age, 45)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces a factory pattern for instantiating LLM clients, supporting direct API calls to OpenAI and Anthropic services, and removing the previous Langchain dependency.

Key changes:
- Added `BaseLLM` interface and concrete `OpenAILLM` and `AnthropicLLM` classes that use the respective Python clients (`openai`, `anthropic`) directly.
- Implemented `LLMFactory` to create LLM instances based on provider ("openai" or "anthropic") and model configurations.
- Updated `EmailAuditor` to use `LLMFactory` for LLM initialization. LLM providers and model names are now configurable via environment variables (e.g., `PRIMARY_LLM_PROVIDER`, `OPENAI_PRIMARY_MODEL`, `ANTHROPIC_REASONING_MODEL`).
- Modified `requirements.txt` to include `openai` and `anthropic` libraries and remove `langchain-openai`.
- Updated `README.md` to reflect the new architecture, API key requirements (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`), and new environment variables for LLM configuration.
- Added comprehensive unit tests for the new LLM classes, the factory, and the EmailAuditor's LLM initialization logic, with mocks for external API calls.

This refactoring allows for more direct control over LLM interactions, removes an intermediate dependency, and provides flexibility in choosing LLM providers and models for different parts of the email auditing process.